### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@
 
 * Prying Deep - [https://github.com/iudicium/pryingdeep](https://github.com/iudicium/pryingdeep)
 
+
+## Tools to proxy the Dark Web
+
+* Tor2Web - [https://github.com/tor2web/Tor2web](https://github.com/tor2web/Tor2web), [https://www.tor2web.org/](https://www.tor2web.org/)
+
+
 ## Miscellaneous
 
 * DeepDarkCTI - [https://github.com/fastfire/deepdarkCTI](https://github.com/fastfire/deepdarkCTI)


### PR DESCRIPTION
Tor2web is an HTTP proxy software that enables access to Tor Hidden Services by mean of common web browsers.

Tor2Web links - https://github.com/tor2web/Tor2web and https://www.tor2web.org/
